### PR TITLE
fixed segfault

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,5 +17,5 @@ add_compile_options(-Wall)
 # Main executable
 add_executable(main main.c)
 set_target_properties(main PROPERTIES
-    LINK_FLAGS "-Wl,-e,custom_entry_point"
+    LINK_FLAGS "-Wl,-defsym=main=custom_entry_point"
 )


### PR DESCRIPTION
# Fixed segfault when trying to link a custom entry point

As far as I can tell, the segfault results in the way c starts the program. Internally, there are other functions called that set up the stack in order for the `main` function to be run. Those functions expect a `main` function.

To solve the problem, you "rename" the `custom_entry_point` to `main` and all the standard setup c does, is maintained.

This can be done by using the `--defysm` linker flag (for documentation see `man ld`):

https://github.com/Ceedrich/c-template/blob/49d8c9985723a591ddd43b58d05868e0036d391f/CMakeLists.txt#L19-L21

I hope this solved your issue :)